### PR TITLE
Update deps, improve bs config, add Redirect binding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ typings/
 
 lib
 .merlin
+*.bs.js

--- a/bsconfig.json
+++ b/bsconfig.json
@@ -6,10 +6,17 @@
       "dir": "src"
     }
   ],
-  "refmt": 3,
-  "bsc-flags": [ "-bs-super-errors" ],
-  "bs-dependencies": [ "reason-react" ],
+  "bsc-flags": ["-bs-super-errors"],
+  "bs-dependencies": ["reason-react"],
   "reason": {
     "react-jsx": 2
-  }
+  },
+  "refmt": 3,
+  "package-specs": [
+    {
+      "module": "es6",
+      "in-source": true
+    }
+  ],
+  "suffix": ".bs.js"
 }

--- a/package.json
+++ b/package.json
@@ -21,16 +21,17 @@
   },
   "homepage": "https://github.com/reasonml-community/bs-react-router#readme",
   "devDependencies": {
-    "bs-platform": "^2.0.0",
-    "react": "^15.4.0",
-    "react-dom": "^15.4.2",
-    "react-router": "^4.1.1",
-    "react-router-dom": "^4.1.1",
+    "bs-platform": "^2.1.0",
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0",
+    "react-router": "^4.2.0",
+    "react-router-dom": "^4.2.2",
     "reason-react": "^0.3.0"
   },
   "peerDependencies": {
-    "react-router": "^4.1.1",
-    "react-router-dom": "^4.1.1",
+    "bs-platform": "^2.1.0",
+    "react-router": ">=4.2.0",
+    "react-router-dom": ">=4.2.0",
     "reason-react": "^0.3.0"
   }
 }

--- a/src/reactRouter.re
+++ b/src/reactRouter.re
@@ -1,20 +1,25 @@
-type renderFunc = 
+type match = {. "params": Js.Dict.t(string)};
+
+type renderFunc =
   {
     .
-    "_match": Js.Dict.t(string),
+    /* Use name mangling notation prefix `_` to circumvent reserved names clashing.
+       https://bucklescript.github.io/docs/en/object.html#invalid-field-names */
+    "_match": match,
     "history": History.History.t,
     "location": History.History.Location.t
   } =>
   ReasonReact.reactElement;
 
-let optionToBool = (optional) => 
+let optionToBool = optional =>
   switch optional {
   | Some(_) => true
   | _ => false
   };
 
 module Route = {
-  [@bs.module "react-router-dom"] external route : ReasonReact.reactClass = "Route";
+  [@bs.module "react-router-dom"]
+  external route : ReasonReact.reactClass = "Route";
   let make =
       (
         ~exact: option(bool)=?,
@@ -35,21 +40,38 @@ module Route = {
     );
 };
 
-module NavLink = {
-  [@bs.module "react-router-dom"] external navLink : ReasonReact.reactClass = "NavLink";
+module Redirect = {
+  [@bs.module "react-router-dom"]
+  external reactClass : ReasonReact.reactClass = "Redirect";
   let make = (~_to: string, children) =>
-    ReasonReact.wrapJsForReason(~reactClass=navLink, ~props={"to": _to}, children);
+    ReasonReact.wrapJsForReason(~reactClass, ~props={"to": _to}, children);
+};
+
+module NavLink = {
+  [@bs.module "react-router-dom"]
+  external navLink : ReasonReact.reactClass = "NavLink";
+  let make = (~_to: string, children) =>
+    ReasonReact.wrapJsForReason(
+      ~reactClass=navLink,
+      ~props={"to": _to},
+      children
+    );
 };
 
 module BrowserRouter = {
   [@bs.module "react-router-dom"]
   external browserRouter : ReasonReact.reactClass = "BrowserRouter";
-  let make = (children) =>
-    ReasonReact.wrapJsForReason(~reactClass=browserRouter, ~props=Js.Obj.empty(), children);
+  let make = children =>
+    ReasonReact.wrapJsForReason(
+      ~reactClass=browserRouter,
+      ~props=Js.Obj.empty(),
+      children
+    );
 };
 
 module ServerRouter = {
-  [@bs.module "react-router"] external staticRouter : ReasonReact.reactClass = "StaticRouter";
+  [@bs.module "react-router"]
+  external staticRouter : ReasonReact.reactClass = "StaticRouter";
   let make = (~context: Js.Json.t, ~location: Js.Json.t, children) =>
     ReasonReact.wrapJsForReason(
       ~reactClass=staticRouter,
@@ -57,5 +79,3 @@ module ServerRouter = {
       children
     );
 };
-
-let withROuter = (component) => <Route render=component />;


### PR DESCRIPTION
Small improvements. I left out some other improvements which are covered by the #6 PR.

In details:
* use `in-source` mode to generate `*.bs.js` files next to the source
* compiled sources are in `es6`
* upgraded some deps versions
  * added `bs-platform` as a `peerDependency`
* be more specific about the `match` object shape (`params`)
* added bindings for `Redirect` component
* removed unnecessary `withROuter` function