### PR TITLE
Allow to specify match params shape

### DIFF
--- a/src/reactRouter.re
+++ b/src/reactRouter.re
@@ -1,11 +1,34 @@
-type match = {. "params": Js.Dict.t(string)};
+module type RouteMatchParams = {type params;};
+
+/**
+ * This functor allows you to specify the types of the match params that
+ * you expect in your React component.
+ * Use this when you are sure that the React component rendered by a Route
+ * receives the given params.
+ *
+ * Usage:
+ *
+module RouterMatch =
+  SpecifyRouterMatch(
+    {
+      type params = {. "postId": string};
+    }
+  );
+
+let make = (~match: RouterMatch.match, _children) => {...};
+ */
+module SpecifyRouterMatch = (Config: RouteMatchParams) => {
+  type match = {. "params": Config.params};
+};
+
+type genericMatch = {. "params": Js.Dict.t(string)};
 
 type renderFunc =
   {
     .
     /* Use name mangling notation prefix `_` to circumvent reserved names clashing.
        https://bucklescript.github.io/docs/en/object.html#invalid-field-names */
-    "_match": match,
+    "_match": genericMatch,
     "history": History.History.t,
     "location": History.History.Location.t
   } =>


### PR DESCRIPTION
This PR adds a little functor that allows to specify the shape of the params that the React component is "sure" to accept.

The main reason for doing this is to avoid having _optional_ params when we are "sure" that the router passes the params to the given component.

```reason
/* before */
let make = (~match: genericMatch, _children) => {
  let postId = Js.Dict.get(match##params, "postId");
  {
    ...component,
    render: _self =>
      switch postId {
        | None => {
          Js.log("Missing postId param");
          ReasonReact.nullElement;
        }
        | Some(id) => <div> (ReasonReact.stringToElement(id)) </div>
      }
  };
};

/* after */
module RouterMatch =
  SpecifyRouterMatch(
    {
      type params = {. "postId": string};
    }
  );

let make = (~match: RouterMatch.match, _children) => {
  ...component,
  render: _self => <div> (ReasonReact.stringToElement(match##params##postId)) </div>
};
```